### PR TITLE
[FEATURE] LLM 이전 대화 입력 및 모델변경

### DIFF
--- a/src/main/java/com/ohgiraffers/backendapi/domain/aichat/dto/AiChatDTO.java
+++ b/src/main/java/com/ohgiraffers/backendapi/domain/aichat/dto/AiChatDTO.java
@@ -63,7 +63,8 @@ public class AiChatDTO {
         private String user_msg;
         private String chat_type;
         private String rag_context;
-        // previous_messages 등 필요 시 추가
+        // previous_messages: [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]
+        private java.util.List<java.util.Map<String, String>> previous_messages;
     }
 
     @Getter

--- a/src/main/java/com/ohgiraffers/backendapi/domain/aichat/repository/BookAiChatRepository.java
+++ b/src/main/java/com/ohgiraffers/backendapi/domain/aichat/repository/BookAiChatRepository.java
@@ -23,6 +23,13 @@ public interface BookAiChatRepository extends JpaRepository<BookAiChat, Long> {
     List<BookAiChat> findByChatRoomOrderByCreatedAtAsc(BookAiChatRoom chatRoom);
 
     /**
+     * 최근 대화 내역 5개 조회 (최신순)
+     * 질문+답변이 하나의 레코드라면 5개면 충분하지만, 여기선 하나의 레코드에 질문/답변이 다 있음.
+     * 따라서 최근 5개의 레코드를 가져오면 5쌍(총 10개 메시지)이 됨.
+     */
+    List<BookAiChat> findTop5ByChatRoomOrderByCreatedAtDesc(BookAiChatRoom chatRoom);
+
+    /**
      * 채팅방의 메시지 페이징 조회 (최신순)
      */
     Page<BookAiChat> findByChatRoom(BookAiChatRoom chatRoom, Pageable pageable);


### PR DESCRIPTION
#27 
## 어떤 기능인가요?

> LLM이 이전 대화를 인지하도록 하고, 기존 사용 모델을 이원화

## 작업 상세 내용

- [x] LLM이 이전 5개의 대화 기록을 인지하도록 함.
- [x] LLM 모델을 gpt-4o-mini 에서 'gpt-5-nano-2025-08-07'와 'gpt-5-mini-2025-08-07'로 변경