### PR TITLE
fix: Update health check path for /api context-path

### DIFF
--- a/.ebextensions/healthcheck.config
+++ b/.ebextensions/healthcheck.config
@@ -1,6 +1,6 @@
 option_settings:
   aws:elasticbeanstalk:environment:process:default:
-    HealthCheckPath: /actuator/health
+    HealthCheckPath: /api/actuator/health
     HealthCheckInterval: 15
     HealthCheckTimeout: 5
     HealthyThresholdCount: 3


### PR DESCRIPTION
- Changed HealthCheckPath from /actuator/health to /api/actuator/health
- Required due to context-path: /api activation
- Fixes Severe health status and 100% 4xx errors