### PR TITLE
fix: Add /api prefix back to OAuth redirect URIs

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -57,7 +57,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: ${SERVER_URL}/login/oauth2/code/kakao
+            redirect-uri: ${SERVER_URL}/api/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope: profile_nickname, profile_image
@@ -70,7 +70,7 @@ spring:
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            redirect-uri: ${SERVER_URL}/login/oauth2/code/naver
+            redirect-uri: ${SERVER_URL}/api/login/oauth2/code/naver
             authorization-grant-type: authorization_code
             scope: name, email, profile_image
             client-name: Naver
@@ -80,7 +80,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: ${SERVER_URL}/login/oauth2/code/google
+            redirect-uri: ${SERVER_URL}/api/login/oauth2/code/google
             scope: profile, email
 
         # --- Provider 설정 (필수!) ---


### PR DESCRIPTION
- Context-path does NOT affect redirect URIs sent to OAuth providers
- Must explicitly include /api in redirect-uri configuration
- Fixes Kakao redirect URI mismatch error (KOE006)